### PR TITLE
Use tokenless upload functionality to publish Codecov reports

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,7 +41,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
   mutation_testing:
     name: Mutation testing


### PR DESCRIPTION
PRs made from forks can successfully publish the code coverage report.

https://github.com/codecov/codecov-action/releases/tag/v1.0.6