### PR TITLE
PHPStan doesn't know about psalm `empty`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "require": {
         "php": ">=7.3",
         "ext-json": "*",
+        "phpstan/phpstan": "0.12.23",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0"
@@ -16,7 +17,6 @@
         "infection/infection": "^0.16.1",
         "php-http/curl-client": "^2.0",
         "php-http/mock-client": "^1.3",
-        "phpstan/phpstan": "^0.12.8",
         "phpstan/phpstan-phpunit": "^0.12.6",
         "phpstan/phpstan-strict-rules": "^0.12.2",
         "phpunit/phpunit": "^9.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,64 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "49f6f4fb94eb5ccaf0c89f1067d143e5",
+    "content-hash": "353920e2c2954a2f38be316dca180d81",
     "packages": [
+        {
+            "name": "phpstan/phpstan",
+            "version": "0.12.23",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "71e529efced79e055fa8318b692e7f7d03ea4e75"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/71e529efced79e055fa8318b692e7f7d03ea4e75",
+                "reference": "71e529efced79e055fa8318b692e7f7d03ea4e75",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.12-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpstan",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-05T12:55:44+00:00"
+        },
         {
             "name": "psr/http-client",
             "version": "1.0.0",
@@ -2306,48 +2362,6 @@
             ],
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "time": "2020-01-25T20:42:48+00:00"
-        },
-        {
-            "name": "phpstan/phpstan",
-            "version": "0.12.19",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "054f6d76b12ba9a6c13a5a8d5fcdf51219615f4d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/054f6d76b12ba9a6c13a5a8d5fcdf51219615f4d",
-                "reference": "054f6d76b12ba9a6c13a5a8d5fcdf51219615f4d",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1"
-            },
-            "conflict": {
-                "phpstan/phpstan-shim": "*"
-            },
-            "bin": [
-                "phpstan",
-                "phpstan.phar"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.12-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "PHPStan - PHP Static Analysis Tool",
-            "time": "2020-04-19T20:35:10+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -4840,5 +4854,6 @@
         "php": ">=7.3",
         "ext-json": "*"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/src/Storage/RedisStore.php
+++ b/src/Storage/RedisStore.php
@@ -249,7 +249,7 @@ final class RedisStore implements Store, CounterStorage, GaugeStorage, Histogram
 
     /**
      * @return array<int,array<string,mixed>>
-     *
+     * @phpstan-return array<array{name:string, help:string, labelNames: string[], type:'gauge', samples: list<array{name:string, labelNames:array<mixed>, labelValues: string[], value: float}>}>
      * @psalm-return array<array{name:string, help:string, labelNames: string[], type:'gauge', samples: list<array{name:string, labelNames:array<empty,empty>, labelValues: string[], value: float}>}>
      */
     private function collectGauges() : array
@@ -295,7 +295,7 @@ final class RedisStore implements Store, CounterStorage, GaugeStorage, Histogram
 
     /**
      * @return array<int,array<string,mixed>>
-     *
+     * @phpstan-return array<array{name:string, help:string, labelNames: string[], type:'counter', samples: list<array{name:string, labelNames:array<mixed>, labelValues: string[], value: float}>}>
      * @psalm-return array<array{name:string, help:string, labelNames: string[], type:'counter', samples: list<array{name:string, labelNames:array<empty,empty>, labelValues: string[], value: float}>}>
      */
     private function collectCounters() : array

--- a/src/Storage/RedisStore.php
+++ b/src/Storage/RedisStore.php
@@ -249,6 +249,7 @@ final class RedisStore implements Store, CounterStorage, GaugeStorage, Histogram
 
     /**
      * @return array<int,array<string,mixed>>
+     *
      * @phpstan-return array<array{name:string, help:string, labelNames: string[], type:'gauge', samples: list<array{name:string, labelNames:array<mixed>, labelValues: string[], value: float}>}>
      * @psalm-return array<array{name:string, help:string, labelNames: string[], type:'gauge', samples: list<array{name:string, labelNames:array<empty,empty>, labelValues: string[], value: float}>}>
      */
@@ -295,6 +296,7 @@ final class RedisStore implements Store, CounterStorage, GaugeStorage, Histogram
 
     /**
      * @return array<int,array<string,mixed>>
+     *
      * @phpstan-return array<array{name:string, help:string, labelNames: string[], type:'counter', samples: list<array{name:string, labelNames:array<mixed>, labelValues: string[], value: float}>}>
      * @psalm-return array<array{name:string, help:string, labelNames: string[], type:'counter', samples: list<array{name:string, labelNames:array<empty,empty>, labelValues: string[], value: float}>}>
      */

--- a/src/Storage/RedisStore.php
+++ b/src/Storage/RedisStore.php
@@ -250,7 +250,7 @@ final class RedisStore implements Store, CounterStorage, GaugeStorage, Histogram
     /**
      * @return array<int,array<string,mixed>>
      *
-     * @phpstan-return array<array{name:string, help:string, labelNames: string[], type:'gauge', samples: list<array{name:string, labelNames:array<mixed>, labelValues: string[], value: float}>}>
+     * @phpstan-return array<array{name:string, help:string, labelNames: string[], type:'gauge', samples: list<array{name:string, labelNames:string[], labelValues:string[], value: float}>}>
      * @psalm-return array<array{name:string, help:string, labelNames: string[], type:'gauge', samples: list<array{name:string, labelNames:array<empty,empty>, labelValues: string[], value: float}>}>
      */
     private function collectGauges() : array
@@ -297,7 +297,7 @@ final class RedisStore implements Store, CounterStorage, GaugeStorage, Histogram
     /**
      * @return array<int,array<string,mixed>>
      *
-     * @phpstan-return array<array{name:string, help:string, labelNames: string[], type:'counter', samples: list<array{name:string, labelNames:array<mixed>, labelValues: string[], value: float}>}>
+     * @phpstan-return array<array{name:string, help:string, labelNames: string[], type:'counter', samples: list<array{name:string, labelNames:string[], labelValues: string[], value: float}>}>
      * @psalm-return array<array{name:string, help:string, labelNames: string[], type:'counter', samples: list<array{name:string, labelNames:array<empty,empty>, labelValues: string[], value: float}>}>
      */
     private function collectCounters() : array


### PR DESCRIPTION
This error was slient until 0.12.20 so we have to
have a specific return for each tool as suggested
by maintainer: https://github.com/phpstan/phpstan/issues/3253

This is needed to bump phpstan.