### PR TITLE
Do not render metrics with incoherent labels

### DIFF
--- a/src/Renderer/IncoherentMetricLabelNamesAndValues.php
+++ b/src/Renderer/IncoherentMetricLabelNamesAndValues.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Enalean\Prometheus\Renderer;
+
+use Enalean\Prometheus\MetricFamilySamples;
+use LogicException;
+use RuntimeException;
+
+use function sprintf;
+
+final class IncoherentMetricLabelNamesAndValues extends RuntimeException
+{
+    /** @var MetricFamilySamples */
+    private $metric;
+
+    public function __construct(MetricFamilySamples $metric, int $nbLabelNames, int $nbLabelValues)
+    {
+        if ($nbLabelNames === $nbLabelValues) {
+            throw new LogicException(
+                sprintf('Label names and values seems to be coherent, both have %d elements', $nbLabelNames),
+            );
+        }
+
+        parent::__construct(
+            sprintf(
+                'Cannot render a sample of the metric %s, got %d names for %d values. Try to flush your store?',
+                $metric->getName(),
+                $nbLabelNames,
+                $nbLabelValues
+            )
+        );
+        $this->metric = $metric;
+    }
+
+    public function getMetric(): MetricFamilySamples
+    {
+        return $this->metric;
+    }
+}

--- a/src/Renderer/MetricsRenderer.php
+++ b/src/Renderer/MetricsRenderer.php
@@ -11,6 +11,8 @@ interface MetricsRenderer
     /**
      * @param MetricFamilySamples[] $metrics
      *
+     * @throws IncoherentMetricLabelNamesAndValues
+     *
      * @psalm-pure
      */
     public function render(array $metrics): string;

--- a/tests/unit/Renderer/IncoherentMetricLabelNamesAndValuesTest.php
+++ b/tests/unit/Renderer/IncoherentMetricLabelNamesAndValuesTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Enalean\PrometheusTest\Renderer;
+
+use Enalean\Prometheus\MetricFamilySamples;
+use Enalean\Prometheus\Renderer\IncoherentMetricLabelNamesAndValues;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers Enalean\Prometheus\Renderer\IncoherentMetricLabelNamesAndValues
+ */
+final class IncoherentMetricLabelNamesAndValuesTest extends TestCase
+{
+    public function testHasACoherentErrorMessage(): void
+    {
+        $metrics = new MetricFamilySamples('some_name', 'counter', 'Help phrase', [], []);
+
+        $exception = new IncoherentMetricLabelNamesAndValues($metrics, 2, 3);
+
+        self::assertStringStartsWith('Cannot render a sample of the metric some_name, got 2 names for 3 values', $exception->getMessage());
+        self::assertSame($metrics, $exception->getMetric());
+    }
+
+    public function testCannotInstantiateExceptionIfLabelNamesAndValuesAppearToBeCoherent(): void
+    {
+        $metrics = new MetricFamilySamples('some_name', 'counter', 'Help phrase', [], []);
+
+        $this->expectException(LogicException::class);
+        new IncoherentMetricLabelNamesAndValues($metrics, 2, 2);
+    }
+}

--- a/tests/unit/Renderer/RenderTextFormatTest.php
+++ b/tests/unit/Renderer/RenderTextFormatTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Enalean\PrometheusTest\Renderer;
 
 use Enalean\Prometheus\MetricFamilySamples;
+use Enalean\Prometheus\Renderer\IncoherentMetricLabelNamesAndValues;
 use Enalean\Prometheus\Renderer\RenderTextFormat;
 use Enalean\Prometheus\Sample;
 use PHPUnit\Framework\TestCase;
@@ -59,6 +60,30 @@ test_some_metric_gauge 0
 ',
             $renderer->render($metrics)
         );
+    }
+
+    /**
+     * @covers Enalean\Prometheus\Renderer\RenderTextFormat
+     */
+    public function testRenderingDoesNotSucceedWhenAllSamplesDoesNotHaveAllTheDefinedLabels(): void
+    {
+        $renderer = new RenderTextFormat();
+
+        $metrics = [
+            new MetricFamilySamples(
+                'B',
+                'counter',
+                'test B',
+                ['label1', 'label2'],
+                [
+                    new Sample('test_some_metric_counter', 1, [], ['value1', 'value2']),
+                    new Sample('test_some_metric_counter', 1, [], ['value1']),
+                ]
+            ),
+        ];
+
+        $this->expectException(IncoherentMetricLabelNamesAndValues::class);
+        $renderer->render($metrics);
     }
 
     /**


### PR DESCRIPTION
This contribution tries to prevent situations where the rendered
information could be incorrect.
If a new label is added (or removed) to a metric and the datastore is
not flushed after the addition (or removal) it is not possible to
determine the correspondance between the label name and a value (at
least not with the current design of the data stores).

Instead of throwing warnings and trying to still render the information,
we should stop and give the opportunity to fix the inconsistency of the
data store.