### PR TITLE
Replace PHP 8.0 RC5 by PHP 8.0 in integration tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php: [ '7.3', '7.4', '8.0.0RC5' ]
+        php: [ '7.3', '7.4', '8.0' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4


### PR DESCRIPTION
The RC5 was used because the 8.0 image was not yet available on the Docker Hub.