### PR TITLE
Passed to redis multi method default param directly

### DIFF
--- a/src/Storage/RedisStore.php
+++ b/src/Storage/RedisStore.php
@@ -340,7 +340,7 @@ final class RedisStore implements Store, CounterStorage, GaugeStorage, Histogram
 
     private function redisMulti(): Redis
     {
-        $redis = $this->redis->multi();
+        $redis = $this->redis->multi(Redis::MULTI);
         /** @phpstan-ignore-next-line */
         assert($redis instanceof Redis);
 


### PR DESCRIPTION
Hello.

When using Symfony we have issue with container and proxy.

More info in same issue https://github.com/phpredis/phpredis/issues/1476#issuecomment-445968070

Example how to fixed in another library https://github.com/Seldaek/monolog/pull/1412/files