### PR TITLE
Fix exception message when PSR18UnexpectedPushGatewayResponse is thrown

### DIFF
--- a/src/PushGateway/PSR18UnexpectedPushGatewayResponse.php
+++ b/src/PushGateway/PSR18UnexpectedPushGatewayResponse.php
@@ -14,13 +14,13 @@ final class PSR18UnexpectedPushGatewayResponse extends UnexpectedPushGatewayResp
     {
         $exceptionCode = 0;
 
-        $message = 'Cannot connect PushGateway server to ' . $request->getUri()->__toString() . ':';
+        $message = 'Cannot connect PushGateway server to ' . $request->getUri()->__toString();
         if ($response !== null) {
-            $message = ' ' . $response->getStatusCode() . ' ' . $response->getReasonPhrase();
+            $message .= ': ' . $response->getStatusCode() . ' ' . $response->getReasonPhrase();
         }
 
         if ($clientException !== null) {
-            $message       = ' ' . $clientException->getMessage();
+            $message      .= ': ' . $clientException->getMessage();
             $exceptionCode = $clientException->getCode();
         }
 

--- a/tests/unit/PushGateway/PSR18UnexpectedPushGatewayResponseTest.php
+++ b/tests/unit/PushGateway/PSR18UnexpectedPushGatewayResponseTest.php
@@ -20,6 +20,7 @@ final class PSR18UnexpectedPushGatewayResponseTest extends TestCase
 
         $exception = PSR18UnexpectedPushGatewayResponse::invalidResponse($request, $response);
 
+        self::assertStringContainsString('Cannot connect PushGateway server to /: 500 Internal', $exception->getMessage());
         self::assertSame($request, $exception->getRequest());
         self::assertSame($response, $exception->getResponse());
         self::assertNull($exception->getPrevious());
@@ -29,11 +30,12 @@ final class PSR18UnexpectedPushGatewayResponseTest extends TestCase
     public function testRequestFailure(): void
     {
         $request         = Psr17FactoryDiscovery::findRequestFactory()->createRequest('PUT', '/');
-        $clientException = new class extends Exception implements ClientExceptionInterface {
+        $clientException = new class ('some reason') extends Exception implements ClientExceptionInterface {
         };
 
         $exception = PSR18UnexpectedPushGatewayResponse::requestFailure($request, $clientException);
 
+        self::assertStringContainsString('Cannot connect PushGateway server to /: some reason', $exception->getMessage());
         self::assertSame($request, $exception->getRequest());
         self::assertNull($exception->getResponse());
         self::assertSame($clientException, $exception->getPrevious());


### PR DESCRIPTION
The message was incorrect, it contained only some details but the context was missing.