### PR TITLE
fix: Fix workflows so they stop failing when starting Docker Compose env

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -86,17 +86,17 @@ jobs:
         run: composer install --no-interaction --prefer-dist
       - name: Start stack
         run: |
-          docker-compose up -d
+          docker compose up -d
           sleep 10
           docker ps -a
         env:
           PHP_VERSION: ${{ matrix.php }}
       - name: Tests with Redis
-        run: docker-compose exec -T phpunit env ADAPTER=redis vendor/bin/phpunit --testsuite=functionnal
+        run: docker compose exec -T phpunit env ADAPTER=redis vendor/bin/phpunit --testsuite=functionnal
         env:
           PHP_VERSION: ${{ matrix.php }}
       - name: Tests with APCU
-        run: docker-compose exec -T phpunit env ADAPTER=apcu vendor/bin/phpunit --testsuite=functionnal
+        run: docker compose exec -T phpunit env ADAPTER=apcu vendor/bin/phpunit --testsuite=functionnal
         env:
           PHP_VERSION: ${{ matrix.php }}
   code_quality:


### PR DESCRIPTION
https://github.blog/changelog/2024-04-10-github-hosted-runner-images-deprecation-notice-docker-compose-v1/